### PR TITLE
Added the bot struct to allow multiple instances

### DIFF
--- a/src/cl-harmony.lisp
+++ b/src/cl-harmony.lisp
@@ -1,25 +1,34 @@
-(ql:quickload "dexador")
 
-;; should these be constants?
-(defvar bot-url "N/A")
-(defvar bot-ver-str "0.0.1")
-(defvar discord-api-ver "v6")
-(defvar discord-api-base-url "https://discordapp.com/api")
-
+;; (TODO:) we should move this into a util.lisp file eventually
 (defun str-concat (&rest strings)
   (apply #'concatenate 'string strings))
 
-;; unsure if the url and version string should be quoted or not in the header
-(defun mk-user-agent-str ()
-  (str-concat "DiscordBot ('" bot-url "', '" bot-ver-str "')"))
 
-(defun mk-headers (token)
-  (list (cons "Authorization" (str-concat "Bot " token))
-        (cons "User-Agent" (mk-user-agent-str))
-        (cons "Content-length" "0")))
+(defstruct (bot (:constructor primitive-bot-make))
+  (token "" :type string :read-only t)
+  (version "0.0.1" :type string)
+  (url "N/A" :type string)
+  (base-url "" :type string))
 
-(defun mk-api-url (endpoint)
-  (str-concat discord-api-base-url "/" discord-api-ver "/" endpoint))
+(defun make-bot (token &key
+			 (version "0.0.1")
+			 (url "N/A")
+			 (api-ver "v6"))
+  (unless token (error "No token specified!"))
+  (primitive-bot-make :token token
+		      :version version
+		      :url url
+		      :base-url (str-concat "https://discordapp.com/api/"
+					    api-ver
+					    "/")))
+
+(defun user-agent (bot)
+  (str-concat "DiscordBot (" (bot-url bot) ", " (bot-version bot) ")"))
+
+(defun headers (bot &optional (length 0))
+  (list (cons "Authorization" (str-concat "Bot " (bot-token bot)))
+        (cons "User-Agent" (user-agent bot))
+        (cons "Content-length" (format nil "~a" length))))
 
 ;; is 'get' reserved?
 (defun get-rq (endpoint)


### PR DESCRIPTION
The bot struct contains most of the important information of any specific bot instance, for example the bot token, bot version etc.