### PR TITLE
Don't look up reaction emoji with no id field in the cache

### DIFF
--- a/src/gateway.lisp
+++ b/src/gateway.lisp
@@ -196,7 +196,9 @@
 
 
 (defun on-reaction (data bot kind)
-  (let ((emoji (cache :emoji (gethash "emoji" data)))
+  (let ((emoji (if (gethash "id" (gethash "emoji" data))
+                   (cache :emoji (gethash "emoji" data))
+                   (gethash "emoji" data)))
         (user (getcache-id (parse-snowflake (gethash "user_id" data))
                            :user))
         (channel (getcache-id (parse-snowflake (gethash "channel_id" data))


### PR DESCRIPTION
The cache lookup assumes that an integer can be parsed from the id field, but this isn't the case for Unicode emoji, so an error is signalled when a user reacts to a message with a Unicode emoji. Note: it may be better to instead make the cache lookup function simply return its input when the `id` field is not a string, to avoid users having to make this same check in their code when looking up an emoji