### PR TITLE
Fix disconnect method calling itself

### DIFF
--- a/src/gateway.lisp
+++ b/src/gateway.lisp
@@ -394,9 +394,9 @@
         (let ((*error-output* out))
           (dprint :info "~a disconnecting...~%"
                   (if (bot-user bot) (lc:name (bot-user bot))))
-          (wsd:close-connection (bot-conn bot) reason code)
           (setf (bot-seq bot) 0)
           (setf (bot-session-id bot) nil)
+          (wsd:close-connection (bot-conn bot) reason code)
           (bt:destroy-thread (bot-heartbeat-thread bot))))))))
 
 (defun cleanup (bot)


### PR DESCRIPTION
Currently, the disconnect method calls `wsd:close-connection`, which itself calls disconnect if `bot-session-id` is set. This results in this error when disconnect is called (this is the provided pingbot receiving `bye!`):

```
test jaybot disconnecting...
Websocket closed with code: NIL
Reason: NIL
test jaybot disconnecting...

debugger invoked on a SB-THREAD:INTERRUPT-THREAD-ERROR in thread
#<THREAD "Anonymous thread" RUNNING {1003D51FA3}>:
  Interrupt thread failed: thread #<THREAD "Anonymous thread" ABORTED
                                     {10034DEDB3}> has exited.

^C
debugger invoked on a SB-SYS:INTERACTIVE-INTERRUPT in thread
#<THREAD "main thread" RUNNING {1001B50193}>:
  Interactive interrupt at #x7F868F5EB819.

Type HELP for debugger help, or (SB-EXT:EXIT) to exit from SBCL.

restarts (invokable by number or by possibly-abbreviated name):
  0: [CONTINUE] Return from SB-UNIX:SIGINT.
  1: [ABORT   ] Exit debugger, returning to top level.

((FLET SB-UNIX::RUN-HANDLER :IN SB-SYS:ENABLE-INTERRUPT) 13 #.(SB-SYS:INT-SAP #X7F868EF7EFB0) #.(SB-SYS:INT-SAP #X7F868EF7EE80))
0] 
```

An easy workaround is just unsetting `bot-session-id` before calling `wsd:close-connection`, but I'm not sure if this is safe. I can avoid recursion by setting a global if you'd prefer that instead.