### PR TITLE
init change

### DIFF
--- a/src/classes/guild.lisp
+++ b/src/classes/guild.lisp
@@ -1,32 +1,34 @@
 (in-package :lispcord.classes)
 
+(deftype js-boolean () '(member :true :false))
+
 (defclass partial-role ()
-  ((name        :initarg :name     :accessor name)
-   (color       :initarg :color    :accessor color)
-   (hoist       :initarg :hoist    :accessor hoistp)
+  ((name        :initarg :name    :accessor name)
+   (color       :initarg :color   :accessor color)
+   (hoist       :initarg :hoist   :accessor hoistp)
    (permissions :initarg :perms   :accessor permissions)
    (mentionable :initarg :mention :accessor mentionablep)))
 
 (defmethod make-role (&key
                         (name "new role")
                         (color 0)
-                        hoist
+                        (hoist :false)
                         (permissions 0)
-                        mentionable)
+                        (mentionable :false))
   (make-instance 'partial-role
                  :name name
                  :color color
-                 :hoist (or hoist :false)
+                 :hoist hoist
                  :perms permissions
-                 :mention (or mentionable :false)))
+                 :mention mentionable))
 
 (defmethod %to-json ((r partial-role))
   (with-object
     (write-key-value "name" (name r))
     (write-key-value "color" (color r))
-    (write-key-value "hoist" (or (hoistp r) :false))
+    (write-key-value "hoist" (hoistp r))
     (write-key-value "permissions" (permissions r))
-    (write-key-value "mentionable" (or (mentionablep r) :false))))
+    (write-key-value "mentionable" (mentionablep r))))
 
 (defclass role ()
   ((id          :initarg :id

--- a/src/http/core.lisp
+++ b/src/http/core.lisp
@@ -4,7 +4,7 @@
 
 (defgeneric from-id (snowflake from &optional bot)
   (:documentation "Retrieves the given object via ID, either from the cache or through a REST call.
-FROM can be one of :CHANNEL, :GUILD, :USER, :EMOJI, :ROLE or a 
+FROM can be one of :CHANNEL, :GUILD, :USER, :EMOJI, :ROLE or a
 discord-place like a channel, a guild and so on"))
 
 ;; (defmethod from-id ((s string) any &optional (bot *client*))

--- a/src/lispcord.lisp
+++ b/src/lispcord.lisp
@@ -71,9 +71,9 @@
 (defun remove-mention (user msg)
   (declare (type lc:user user)
      (type string msg))
-  (or (remove-substring (str-concat "<@" (to-string (lc:id user)) ">")
+  (or (remove-substring (str-concat "<@" (lc:id user) ">")
                         msg)
-      (remove-substring (str-concat "<@!" (to-string (lc:id user)) ">")
+      (remove-substring (str-concat "<@!" (lc:id user) ">")
                         msg)
       msg))
 

--- a/src/pipes.lisp
+++ b/src/pipes.lisp
@@ -17,9 +17,9 @@
 
 (defun dispatch-event (event-key args &optional (bot *client*))
   (apply (gethash event-key (bot-event-handlers bot)
-      (lambda (&rest _)
-        (declare (ignore _))
-        nil))
-   args))
+                  (lambda (&rest _)
+                    (declare (ignore _))
+                    nil))
+         args))
 
 

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -1,38 +1,38 @@
 (defpackage :lispcord.util
   (:use :cl :split-sequence)
   (:export #:mapvec
-     #:str-concat
-     #:jparse
-     #:jmake
-     #:doit
-     #:sethash
-     #:make-nonce
-     #:mapf
-     #:with-table
-     #:instance-from-table
-     #:since-unix-epoch
-     #:*unix-epoch*
-     #:vec-extend
-     #:vecrem
-     #:recur
+           #:str-concat
+           #:jparse
+           #:jmake
+           #:doit
+           #:sethash
+           #:make-nonce
+           #:mapf
+           #:with-table
+           #:instance-from-table
+           #:since-unix-epoch
+           #:*unix-epoch*
+           #:vec-extend
+           #:vecrem
+           #:recur
 
-     #:split-sequence
+           #:split-sequence
 
-     #:snowflake
-     #:parse-snowflake
-     #:to-string
-     #:optimal-id-compare))
+           #:snowflake
+           #:parse-snowflake
+           #:to-string
+           #:optimal-id-compare))
 
 (in-package :lispcord.util)
 
 (declaim (inline parse-snowflake
-     to-string
-     str-concat
-     jparse
-     jmake
-     since-unix-epoch
-     sethash
-     vecrem))
+                 to-string
+                 str-concat
+                 jparse
+                 jmake
+                 since-unix-epoch
+                 sethash
+                 vecrem))
 
 ;; this type allows us to later potentially convert the IDs to numbers
 ;; without needing to rewrite all the type declerations!
@@ -63,10 +63,10 @@
   (let ((it (intern (symbol-name 'it))))
     `(let (,it)
        ,@(mapcar (lambda (f)
-       (if (eq :! (car f))
-           (cdr f)
-           `(setf ,it ,f)))
-     forms))))
+                   (if (eq :! (car f))
+                       (cdr f)
+                       `(setf ,it ,f)))
+                 forms))))
 
 (defmethod v:format-message ((stream stream) (message v:message))
   (format stream "~&~a" (v:content message)))
@@ -87,44 +87,46 @@
   (defun make-nonce ()
     (declare (type fixnum cnt))
     (format nil "~d" (+ (* (get-universal-time) 1000000)
-      (incf cnt)))))
-
-(defmacro mapf (list args &body body)
-  `(mapcar (lambda ,args ,@body) ,list))
-
+                        (incf cnt)))))
 
 (defmacro with-table ((table &rest pairs) &body body)
   (labels ((partition (list)
-       (declare (type cons list))
-       (unless (evenp (length list)) (error "Uneven pair list!"))
-       (values (loop :for i :in list :counting i :into c
-      :if (oddp c) :collect i)
-         (loop :for i :in list :counting i :into c
-      :if (evenp c) :collect i)))
-     (key-vals (list)
-       (loop :for i :in list :collect `(gethash ,i ,table))))
+             (declare (type cons list))
+             (unless (evenp (length list))
+               (error "Uneven pair list!"))
+             (loop :for i :from 1
+                :for x :in list
+                :when (oddp i) :collect x :into lst1
+                :when (evenp i) :collect x :into lst2
+                :finally (return (values lst1 lst2))))
+           (key-vals (list)
+             (loop :for i :in list :collect `(gethash ,i ,table))))
     (multiple-value-bind (vars keys) (partition pairs)
-      `(multiple-value-bind ,vars (values ,@(key-vals keys))
-   ,@body))))
+      `(let ,(mapcar (lambda (var val)
+                        `(,var ,val))
+                      vars
+                      (key-vals keys))
+         ,@body))))
 
 
 (defmacro instance-from-table ((table class) &body pairs)
   `(make-instance ,class
-      ,@(loop :for e :in pairs :counting e :into c
-           :when (evenp c)
-           :collect (if (listp e)
-            e
-            `(gethash ,e ,table))
-           :else :collect e)))
+                  ,@(loop :for e :in pairs :counting e :into c
+                       :if (evenp c)
+                       :collect (if (listp e)
+                                    e
+                                    `(gethash ,e ,table))
+                       :else :collect e)))
 
 (defun vec-extend (obj vec)
   (declare (type array vec))
   (let ((buf (make-array (1+ (length vec))
-       :element-type (array-element-type vec))))
+                         :element-type (array-element-type vec))))
     (dotimes (i (length vec))
       (if (null (aref vec i))
-    (progn (setf (aref vec i) obj) (return-from vec-extend vec))
-    (setf (aref buf i) (aref vec i))))
+          (progn (setf (aref vec i) obj)
+                 (return-from vec-extend vec))
+          (setf (aref buf i) (aref vec i))))
     (setf (aref buf (length vec)) obj)
     buf))
 
@@ -136,6 +138,3 @@
 
 (defun vecrem (predicate seq)
   (delete-if predicate seq :from-end t))
-
-(defmacro recur (name &rest args)
-  `(return-from ,name (,name ,@args)))


### PR DESCRIPTION
This pull request mainly contain the following change

### guild.lisp:
- adding :false as part of the make-argument in make-role
- thereby assuming that hoist and mentionable both contain the value :false by default
perhaps this can be further safeguarded by
`(deftype js-boolean () '(member :false :true))` and add :type to these two argument.

### gateway.lisp:
- reformed `network-retry-loop` by using `cond` instead to eliminate the need for `recur` macro
- reformed `mapf` bit to eliminate the need for `mapf` macro
my suggestions are:
macro is very powerful tool indeed, but it hurts the readability for most of the times, and should be used with caution, especially for simple syntaxual transformation, it should only be used for repetitive code patterns, and there was only one of such code usage, therefore, i choose to revert the usage of this macro 
 
### lispcord.lisp: 
- since they are macro calls to format, `to-string` will be overcalling in my opinion, but i do see how it states that we want these variables to be string explicitly, i am not too strong for merging this change.

### utils.lisp
- removed all unnecessary macro definition
- `with-table` changed multiple-values-bind to let bindings, to me `let` is more primitive, would be faster than `multiple-value-bind`, also could be considered better styling in comparison. 
Also it should be considered to have the various bind-var & key pairing come in actual pairs
So
```
emojis "emojis"
id "guild_id"
```
into

```
(emojis "emojis")
(id "guild_id")
```
would be more powerful