### PR TITLE
Make `dm-channel`'s `last-pinned` nullable

### DIFF
--- a/src/classes/channel.lisp
+++ b/src/classes/channel.lisp
@@ -149,7 +149,7 @@
                  :type (vector user)
                  :accessor recipients)
    (last-pinned  :initarg :last-pinned
-                 :type string
+                 :type (or null string)
                  :accessor last-pinned)))
 
 (defclass group-dm (dm-channel)

--- a/src/classes/embed.lisp
+++ b/src/classes/embed.lisp
@@ -6,7 +6,7 @@
 									 :type string
 									 :accessor text)
    (icon           :initarg :icon
-									 :type string
+									 :type (or null string)
 									 :accessor icon)
    (icon-proxy-url :initarg :icon-proxy-url
 									 :type string
@@ -159,13 +159,13 @@
 
 (defclass embed ()
   ((title       :initarg :title
-								:type string
+								:type (or null string)
 								:accessor title)
    (type        :initarg :type
 								:type string
 								:accessor type)
    (description :initarg :description
-								:type string
+								:type (or null string)
 								:accessor description)
    (url         :initarg :url
 								:type string


### PR DESCRIPTION
Because if there aren't any pinned messages, then it's a bug.