### PR TITLE
Updating quickstart example due to the verbose removing a global nickname

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ after cloning the repo to your `~/common-lisp` or `~/quicklisp/local-projects` f
   (:use :cl :lispcord))
 (in-package :ping-bot)
 
-(setf (v:repl-level) :info)
+(setf (org.shirakumo.verbose:repl-level) :info)
 
 (defbot *ping-bot* "<Your Token Here>")
 (connect *ping-bot*) ; Yes, you can register handlers after connect


### PR DESCRIPTION
This was mentioned in #56 and figured out, but README example is still using its old nickname.